### PR TITLE
Fix invalid closing tag in Svelte component

### DIFF
--- a/src/routes/manage-store/[shopID]/+page.svelte
+++ b/src/routes/manage-store/[shopID]/+page.svelte
@@ -724,10 +724,6 @@
         </div>
         </dialog>
     
-    </div>
-</section>
-
-
         <!-- Search and Filter Section -->
         <div class="bg-gray-50 rounded-3xl p-8 mb-12">
             <div class="flex flex-wrap gap-4 items-center justify-between">
@@ -962,10 +958,6 @@
                 </div>
             {/if}
         </div>
-    </div>
-</section>
-
-<!--  -->
 
 <!-- Edit Modal -->
 {#if editingItem}
@@ -1224,6 +1216,9 @@
         </div>
     </div>
 {/if}
+
+    </div>
+</section>
 
 <style>
     .file-input {


### PR DESCRIPTION
Fix HTML structure errors in `manage-store/[shopID]/+page.svelte` to enable successful builds.

The build was failing due to `</div>` and `</section>` tags attempting to close elements that were not open or were closed prematurely, leading to an invalid HTML structure. This PR corrects the nesting of elements within the main section.

---
<a href="https://cursor.com/background-agent?bcId=bc-7068ff74-3d53-4f74-a9c8-fd47b1a0844d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7068ff74-3d53-4f74-a9c8-fd47b1a0844d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

