### PR TITLE
Check for missing lang attribute in style tags

### DIFF
--- a/src/routes/gallery/components/PhotoUpload.svelte
+++ b/src/routes/gallery/components/PhotoUpload.svelte
@@ -217,7 +217,8 @@
 								class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-2xl p-8 text-center hover:border-purple-500 dark:hover:border-purple-400 transition-colors cursor-pointer"
 								class:border-purple-500={isDragOver}
 								class:bg-purple-50={isDragOver}
-								class:dark:bg-purple-900/20={isDragOver}
+								class:dark:bg-purple-900={isDragOver}
+								class:dark:bg-opacity-20={isDragOver}
 								on:dragover={handleDragOver}
 								on:dragleave={handleDragLeave}
 								on:drop={handleDrop}


### PR DESCRIPTION
Fix invalid Tailwind CSS opacity syntax to resolve build failure.

The build error message "Did you forget to add a lang attribute to your style tag?" was misleading. The actual issue was an incorrect Tailwind CSS class `dark:bg-purple-900/20` which combines color and opacity in an unsupported way. This PR separates it into `dark:bg-purple-900` and `dark:bg-opacity-20` to correctly apply the styles and allow the build to succeed.

---
<a href="https://cursor.com/background-agent?bcId=bc-0692f5fd-a98d-44bc-99ca-22d3271ae503">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0692f5fd-a98d-44bc-99ca-22d3271ae503">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

