### PR TITLE
Add brainstorm board routes for feature requests

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -225,6 +225,9 @@
 					<a href="/gallery" class="text-primary hover:text-purple-500 font-medium transition-colors duration-200">
 						🎭 Gallery
 					</a>
+					<a href="/brainstorm" class="text-primary hover:text-green-500 font-medium transition-colors duration-200">
+						🧠 Brainstorm
+					</a>
 					<a href="/pricing" class="text-primary hover:text-blue-500 font-medium transition-colors duration-200">
 						อัพเกรด
 					</a>

--- a/src/routes/brainstorm/+layout.svelte
+++ b/src/routes/brainstorm/+layout.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	let { children } = $props();
+</script>
+
+<div class="brainstorm-layout">
+	{@render children()}
+</div>
+
+<style>
+	.brainstorm-layout {
+		min-height: calc(100vh - 4rem);
+	}
+</style>

--- a/src/routes/brainstorm/+page.svelte
+++ b/src/routes/brainstorm/+page.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { FeatureRequest } from '../../types/brainstorm';
+	import FeatureCard from './components/FeatureCard.svelte';
+	import FeatureForm from './components/FeatureForm.svelte';
+
+	let features: FeatureRequest[] = $state([]);
+	let showForm = $state(false);
+	let loading = $state(true);
+	let error = $state('');
+
+	onMount(async () => {
+		await loadFeatures();
+	});
+
+	async function loadFeatures() {
+		try {
+			loading = true;
+			const response = await fetch('/brainstorm/api');
+			if (response.ok) {
+				features = await response.json();
+			} else {
+				error = 'Failed to load features';
+			}
+		} catch (err) {
+			error = 'Error loading features';
+			console.error('Error loading features:', err);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function handleAddFeature(event: CustomEvent) {
+		try {
+			const response = await fetch('/brainstorm/api', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify(event.detail)
+			});
+
+			if (response.ok) {
+				const newFeature = await response.json();
+				features = [...features, newFeature];
+				showForm = false;
+			} else {
+				error = 'Failed to add feature request';
+			}
+		} catch (err) {
+			error = 'Error adding feature request';
+			console.error('Error adding feature:', err);
+		}
+	}
+
+	async function handleUpdateFeature(event: CustomEvent) {
+		try {
+			const { id, ...updateData } = event.detail;
+			const response = await fetch(`/brainstorm/api/${id}`, {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify(updateData)
+			});
+
+			if (response.ok) {
+				const updatedFeature = await response.json();
+				features = features.map(f => f.id === id ? updatedFeature : f);
+			} else {
+				error = 'Failed to update feature request';
+			}
+		} catch (err) {
+			error = 'Error updating feature request';
+			console.error('Error updating feature:', err);
+		}
+	}
+
+	async function handleDeleteFeature(event: CustomEvent) {
+		try {
+			const { id } = event.detail;
+			const response = await fetch(`/brainstorm/api/${id}`, {
+				method: 'DELETE'
+			});
+
+			if (response.ok) {
+				features = features.filter(f => f.id !== id);
+			} else {
+				error = 'Failed to delete feature request';
+			}
+		} catch (err) {
+			error = 'Error deleting feature request';
+			console.error('Error deleting feature:', err);
+		}
+	}
+
+	function filterByStatus(status: string) {
+		if (status === 'all') return features;
+		return features.filter(f => f.status === status);
+	}
+
+	let selectedFilter = $state('all');
+	$: filteredFeatures = filterByStatus(selectedFilter);
+</script>
+
+<svelte:head>
+	<title>Brainstorm Board - MacOSPlay</title>
+	<meta name="description" content="Feature request brainstorm board for MacOSPlay" />
+</svelte:head>
+
+<div class="min-h-screen bg-base-100 p-6">
+	<div class="max-w-7xl mx-auto">
+		<!-- Header -->
+		<div class="mb-8">
+			<div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+				<div>
+					<h1 class="text-4xl font-bold text-primary mb-2">🧠 Brainstorm Board</h1>
+					<p class="text-base-content/70 text-lg">
+						Share your ideas and vote on features for MacOSPlay
+					</p>
+				</div>
+				<button 
+					class="btn btn-primary btn-lg"
+					onclick={() => showForm = !showForm}
+				>
+					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+					</svg>
+					Add Feature Request
+				</button>
+			</div>
+		</div>
+
+		<!-- Error Display -->
+		{#if error}
+			<div class="alert alert-error mb-6">
+				<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+				</svg>
+				<span>{error}</span>
+				<button class="btn btn-sm btn-ghost" onclick={() => error = ''}>✕</button>
+			</div>
+		{/if}
+
+		<!-- Feature Form Modal -->
+		{#if showForm}
+			<div class="modal modal-open">
+				<div class="modal-box max-w-2xl">
+					<h3 class="font-bold text-lg mb-4">Add New Feature Request</h3>
+					<FeatureForm 
+						on:submit={handleAddFeature}
+						on:cancel={() => showForm = false}
+					/>
+				</div>
+				<div class="modal-backdrop" onclick={() => showForm = false}></div>
+			</div>
+		{/if}
+
+		<!-- Filters -->
+		<div class="mb-6">
+			<div class="flex flex-wrap gap-2">
+				<button 
+					class="btn btn-sm {selectedFilter === 'all' ? 'btn-primary' : 'btn-ghost'}"
+					onclick={() => selectedFilter = 'all'}
+				>
+					All ({features.length})
+				</button>
+				<button 
+					class="btn btn-sm {selectedFilter === 'requested' ? 'btn-primary' : 'btn-ghost'}"
+					onclick={() => selectedFilter = 'requested'}
+				>
+					Requested ({features.filter(f => f.status === 'requested').length})
+				</button>
+				<button 
+					class="btn btn-sm {selectedFilter === 'in-review' ? 'btn-primary' : 'btn-ghost'}"
+					onclick={() => selectedFilter = 'in-review'}
+				>
+					In Review ({features.filter(f => f.status === 'in-review').length})
+				</button>
+				<button 
+					class="btn btn-sm {selectedFilter === 'approved' ? 'btn-primary' : 'btn-ghost'}"
+					onclick={() => selectedFilter = 'approved'}
+				>
+					Approved ({features.filter(f => f.status === 'approved').length})
+				</button>
+				<button 
+					class="btn btn-sm {selectedFilter === 'in-progress' ? 'btn-primary' : 'btn-ghost'}"
+					onclick={() => selectedFilter = 'in-progress'}
+				>
+					In Progress ({features.filter(f => f.status === 'in-progress').length})
+				</button>
+				<button 
+					class="btn btn-sm {selectedFilter === 'completed' ? 'btn-primary' : 'btn-ghost'}"
+					onclick={() => selectedFilter = 'completed'}
+				>
+					Completed ({features.filter(f => f.status === 'completed').length})
+				</button>
+			</div>
+		</div>
+
+		<!-- Loading State -->
+		{#if loading}
+			<div class="flex justify-center items-center py-12">
+				<span class="loading loading-spinner loading-lg"></span>
+			</div>
+		{:else if filteredFeatures.length === 0}
+			<!-- Empty State -->
+			<div class="text-center py-12">
+				<div class="text-6xl mb-4">💡</div>
+				<h3 class="text-2xl font-semibold mb-2">No feature requests yet</h3>
+				<p class="text-base-content/70 mb-6">
+					Be the first to share your ideas for MacOSPlay!
+				</p>
+				<button 
+					class="btn btn-primary"
+					onclick={() => showForm = true}
+				>
+					Add First Feature Request
+				</button>
+			</div>
+		{:else}
+			<!-- Whiteboard Grid -->
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+				{#each filteredFeatures as feature (feature.id)}
+					<FeatureCard 
+						{feature}
+						on:update={handleUpdateFeature}
+						on:delete={handleDeleteFeature}
+					/>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.whiteboard-container {
+		background-image: 
+			linear-gradient(rgba(0,0,0,.1) 1px, transparent 1px),
+			linear-gradient(90deg, rgba(0,0,0,.1) 1px, transparent 1px);
+		background-size: 20px 20px;
+	}
+</style>

--- a/src/routes/brainstorm/api/+server.ts
+++ b/src/routes/brainstorm/api/+server.ts
@@ -1,0 +1,115 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { FeatureRequest, CreateFeatureRequestData } from '../../../types/brainstorm';
+
+// In-memory storage (replace with actual database in production)
+let features: FeatureRequest[] = [
+	{
+		id: '1',
+		title: 'Dark Mode Toggle',
+		description: 'Add a system-wide dark mode toggle that remembers user preference across sessions.',
+		category: 'ui',
+		priority: 'high',
+		status: 'in-progress',
+		author: 'John Doe',
+		votes: 15,
+		createdAt: new Date('2024-01-15').toISOString(),
+		updatedAt: new Date('2024-01-20').toISOString(),
+		tags: ['ui', 'accessibility', 'theme'],
+		position: { x: 100, y: 100 }
+	},
+	{
+		id: '2',
+		title: 'Drag and Drop File Upload',
+		description: 'Allow users to drag and drop files directly into the application for easier file management.',
+		category: 'feature',
+		priority: 'medium',
+		status: 'requested',
+		author: 'Jane Smith',
+		votes: 8,
+		createdAt: new Date('2024-01-18').toISOString(),
+		updatedAt: new Date('2024-01-18').toISOString(),
+		tags: ['file-management', 'ux'],
+		position: { x: 300, y: 150 }
+	},
+	{
+		id: '3',
+		title: 'Keyboard Shortcuts',
+		description: 'Implement comprehensive keyboard shortcuts for power users to navigate and perform actions quickly.',
+		category: 'improvement',
+		priority: 'medium',
+		status: 'approved',
+		author: 'Alex Johnson',
+		votes: 22,
+		createdAt: new Date('2024-01-10').toISOString(),
+		updatedAt: new Date('2024-01-22').toISOString(),
+		tags: ['accessibility', 'productivity', 'shortcuts'],
+		position: { x: 500, y: 200 }
+	},
+	{
+		id: '4',
+		title: 'Export to PDF',
+		description: 'Add functionality to export content and reports as PDF files with customizable formatting options.',
+		category: 'feature',
+		priority: 'low',
+		status: 'requested',
+		author: 'Sarah Wilson',
+		votes: 5,
+		createdAt: new Date('2024-01-25').toISOString(),
+		updatedAt: new Date('2024-01-25').toISOString(),
+		tags: ['export', 'pdf', 'reports'],
+		position: { x: 200, y: 300 }
+	}
+];
+
+function generateId(): string {
+	return Math.random().toString(36).substring(2) + Date.now().toString(36);
+}
+
+export const GET: RequestHandler = async () => {
+	return json(features);
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const data: CreateFeatureRequestData = await request.json();
+		
+		// Validate required fields
+		if (!data.title?.trim()) {
+			return json({ error: 'Title is required' }, { status: 400 });
+		}
+		
+		if (!data.description?.trim()) {
+			return json({ error: 'Description is required' }, { status: 400 });
+		}
+		
+		if (!data.author?.trim()) {
+			return json({ error: 'Author is required' }, { status: 400 });
+		}
+
+		const newFeature: FeatureRequest = {
+			id: generateId(),
+			title: data.title.trim(),
+			description: data.description.trim(),
+			category: data.category,
+			priority: data.priority,
+			status: 'requested',
+			author: data.author.trim(),
+			votes: 0,
+			createdAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+			tags: data.tags || [],
+			position: {
+				x: Math.random() * 400 + 100,
+				y: Math.random() * 400 + 100
+			}
+		};
+
+		features.push(newFeature);
+		
+		return json(newFeature, { status: 201 });
+	} catch (error) {
+		console.error('Error creating feature request:', error);
+		return json({ error: 'Invalid request data' }, { status: 400 });
+	}
+};

--- a/src/routes/brainstorm/api/[id]/+server.ts
+++ b/src/routes/brainstorm/api/[id]/+server.ts
@@ -1,0 +1,120 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { FeatureRequest, UpdateFeatureRequestData } from '../../../../types/brainstorm';
+
+// Import the same features array (in production, use a proper database)
+// For now, we'll simulate database operations
+let features: FeatureRequest[] = [];
+
+// Initialize with sample data (this would be handled by the main API in production)
+if (features.length === 0) {
+	features = [
+		{
+			id: '1',
+			title: 'Dark Mode Toggle',
+			description: 'Add a system-wide dark mode toggle that remembers user preference across sessions.',
+			category: 'ui',
+			priority: 'high',
+			status: 'in-progress',
+			author: 'John Doe',
+			votes: 15,
+			createdAt: new Date('2024-01-15').toISOString(),
+			updatedAt: new Date('2024-01-20').toISOString(),
+			tags: ['ui', 'accessibility', 'theme'],
+			position: { x: 100, y: 100 }
+		},
+		{
+			id: '2',
+			title: 'Drag and Drop File Upload',
+			description: 'Allow users to drag and drop files directly into the application for easier file management.',
+			category: 'feature',
+			priority: 'medium',
+			status: 'requested',
+			author: 'Jane Smith',
+			votes: 8,
+			createdAt: new Date('2024-01-18').toISOString(),
+			updatedAt: new Date('2024-01-18').toISOString(),
+			tags: ['file-management', 'ux'],
+			position: { x: 300, y: 150 }
+		},
+		{
+			id: '3',
+			title: 'Keyboard Shortcuts',
+			description: 'Implement comprehensive keyboard shortcuts for power users to navigate and perform actions quickly.',
+			category: 'improvement',
+			priority: 'medium',
+			status: 'approved',
+			author: 'Alex Johnson',
+			votes: 22,
+			createdAt: new Date('2024-01-10').toISOString(),
+			updatedAt: new Date('2024-01-22').toISOString(),
+			tags: ['accessibility', 'productivity', 'shortcuts'],
+			position: { x: 500, y: 200 }
+		},
+		{
+			id: '4',
+			title: 'Export to PDF',
+			description: 'Add functionality to export content and reports as PDF files with customizable formatting options.',
+			category: 'feature',
+			priority: 'low',
+			status: 'requested',
+			author: 'Sarah Wilson',
+			votes: 5,
+			createdAt: new Date('2024-01-25').toISOString(),
+			updatedAt: new Date('2024-01-25').toISOString(),
+			tags: ['export', 'pdf', 'reports'],
+			position: { x: 200, y: 300 }
+		}
+	];
+}
+
+export const GET: RequestHandler = async ({ params }) => {
+	const feature = features.find(f => f.id === params.id);
+	
+	if (!feature) {
+		return json({ error: 'Feature request not found' }, { status: 404 });
+	}
+	
+	return json(feature);
+};
+
+export const PUT: RequestHandler = async ({ params, request }) => {
+	try {
+		const featureIndex = features.findIndex(f => f.id === params.id);
+		
+		if (featureIndex === -1) {
+			return json({ error: 'Feature request not found' }, { status: 404 });
+		}
+		
+		const updateData: UpdateFeatureRequestData = await request.json();
+		const existingFeature = features[featureIndex];
+		
+		// Update the feature with new data
+		const updatedFeature: FeatureRequest = {
+			...existingFeature,
+			...updateData,
+			id: existingFeature.id, // Ensure ID cannot be changed
+			createdAt: existingFeature.createdAt, // Preserve creation date
+			updatedAt: new Date().toISOString()
+		};
+		
+		features[featureIndex] = updatedFeature;
+		
+		return json(updatedFeature);
+	} catch (error) {
+		console.error('Error updating feature request:', error);
+		return json({ error: 'Invalid request data' }, { status: 400 });
+	}
+};
+
+export const DELETE: RequestHandler = async ({ params }) => {
+	const featureIndex = features.findIndex(f => f.id === params.id);
+	
+	if (featureIndex === -1) {
+		return json({ error: 'Feature request not found' }, { status: 404 });
+	}
+	
+	const deletedFeature = features.splice(featureIndex, 1)[0];
+	
+	return json({ message: 'Feature request deleted successfully', feature: deletedFeature });
+};

--- a/src/routes/brainstorm/components/FeatureCard.svelte
+++ b/src/routes/brainstorm/components/FeatureCard.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import type { FeatureRequest } from '../../../types/brainstorm';
+
+	interface Props {
+		feature: FeatureRequest;
+	}
+
+	let { feature }: Props = $props();
+
+	const dispatch = createEventDispatcher();
+
+	function getPriorityColor(priority: string) {
+		switch (priority) {
+			case 'critical': return 'badge-error';
+			case 'high': return 'badge-warning';
+			case 'medium': return 'badge-info';
+			case 'low': return 'badge-success';
+			default: return 'badge-ghost';
+		}
+	}
+
+	function getStatusColor(status: string) {
+		switch (status) {
+			case 'requested': return 'bg-gray-100 text-gray-800';
+			case 'in-review': return 'bg-blue-100 text-blue-800';
+			case 'approved': return 'bg-green-100 text-green-800';
+			case 'in-progress': return 'bg-yellow-100 text-yellow-800';
+			case 'completed': return 'bg-purple-100 text-purple-800';
+			case 'rejected': return 'bg-red-100 text-red-800';
+			default: return 'bg-gray-100 text-gray-800';
+		}
+	}
+
+	function getCategoryIcon(category: string) {
+		switch (category) {
+			case 'ui': return '🎨';
+			case 'feature': return '✨';
+			case 'improvement': return '📈';
+			case 'bug': return '🐛';
+			default: return '💡';
+		}
+	}
+
+	function handleVote() {
+		dispatch('update', {
+			id: feature.id,
+			votes: feature.votes + 1
+		});
+	}
+
+	function handleStatusChange(newStatus: string) {
+		dispatch('update', {
+			id: feature.id,
+			status: newStatus
+		});
+	}
+
+	function handleDelete() {
+		if (confirm('Are you sure you want to delete this feature request?')) {
+			dispatch('delete', { id: feature.id });
+		}
+	}
+
+	let showDetails = $state(false);
+</script>
+
+<div class="card bg-base-200 shadow-lg hover:shadow-xl transition-all duration-200 border border-base-300">
+	<div class="card-body p-4">
+		<!-- Header -->
+		<div class="flex items-start justify-between mb-3">
+			<div class="flex items-center gap-2">
+				<span class="text-2xl">{getCategoryIcon(feature.category)}</span>
+				<div class="flex flex-col">
+					<span class="text-xs opacity-60">{feature.category.toUpperCase()}</span>
+					<span class="badge {getPriorityColor(feature.priority)} badge-xs">
+						{feature.priority}
+					</span>
+				</div>
+			</div>
+			<div class="dropdown dropdown-end">
+				<label tabindex="0" class="btn btn-ghost btn-xs">⋮</label>
+				<ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
+					<li><button onclick={() => showDetails = !showDetails}>
+						{showDetails ? 'Hide' : 'Show'} Details
+					</button></li>
+					<li><button onclick={handleDelete} class="text-error">Delete</button></li>
+				</ul>
+			</div>
+		</div>
+
+		<!-- Title -->
+		<h3 class="card-title text-base mb-2 line-clamp-2">{feature.title}</h3>
+
+		<!-- Description -->
+		<p class="text-sm opacity-70 mb-3 line-clamp-3">{feature.description}</p>
+
+		<!-- Status -->
+		<div class="mb-3">
+			<select 
+				class="select select-xs w-full max-w-xs {getStatusColor(feature.status)}"
+				value={feature.status}
+				onchange={(e) => handleStatusChange(e.currentTarget.value)}
+			>
+				<option value="requested">Requested</option>
+				<option value="in-review">In Review</option>
+				<option value="approved">Approved</option>
+				<option value="in-progress">In Progress</option>
+				<option value="completed">Completed</option>
+				<option value="rejected">Rejected</option>
+			</select>
+		</div>
+
+		<!-- Tags -->
+		{#if feature.tags.length > 0}
+			<div class="flex flex-wrap gap-1 mb-3">
+				{#each feature.tags.slice(0, 3) as tag}
+					<span class="badge badge-outline badge-xs">{tag}</span>
+				{/each}
+				{#if feature.tags.length > 3}
+					<span class="badge badge-ghost badge-xs">+{feature.tags.length - 3}</span>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Footer -->
+		<div class="flex items-center justify-between pt-2 border-t border-base-300">
+			<div class="flex items-center gap-2">
+				<button 
+					class="btn btn-ghost btn-xs gap-1"
+					onclick={handleVote}
+				>
+					👍 {feature.votes}
+				</button>
+				<span class="text-xs opacity-60">by {feature.author}</span>
+			</div>
+			<span class="text-xs opacity-60">
+				{new Date(feature.createdAt).toLocaleDateString()}
+			</span>
+		</div>
+
+		<!-- Expanded Details -->
+		{#if showDetails}
+			<div class="mt-4 pt-4 border-t border-base-300">
+				<div class="space-y-2 text-sm">
+					<div><strong>ID:</strong> {feature.id}</div>
+					<div><strong>Created:</strong> {new Date(feature.createdAt).toLocaleString()}</div>
+					<div><strong>Updated:</strong> {new Date(feature.updatedAt).toLocaleString()}</div>
+					{#if feature.tags.length > 0}
+						<div>
+							<strong>All Tags:</strong>
+							<div class="flex flex-wrap gap-1 mt-1">
+								{#each feature.tags as tag}
+									<span class="badge badge-outline badge-xs">{tag}</span>
+								{/each}
+							</div>
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.line-clamp-2 {
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	.line-clamp-3 {
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+</style>

--- a/src/routes/brainstorm/components/FeatureForm.svelte
+++ b/src/routes/brainstorm/components/FeatureForm.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import type { CreateFeatureRequestData } from '../../../types/brainstorm';
+
+	const dispatch = createEventDispatcher();
+
+	let formData: CreateFeatureRequestData = $state({
+		title: '',
+		description: '',
+		category: 'feature',
+		priority: 'medium',
+		author: '',
+		tags: []
+	});
+
+	let tagInput = $state('');
+	let errors = $state<Record<string, string>>({});
+
+	function addTag() {
+		if (tagInput.trim() && !formData.tags.includes(tagInput.trim())) {
+			formData.tags = [...formData.tags, tagInput.trim()];
+			tagInput = '';
+		}
+	}
+
+	function removeTag(tagToRemove: string) {
+		formData.tags = formData.tags.filter(tag => tag !== tagToRemove);
+	}
+
+	function handleTagKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			addTag();
+		}
+	}
+
+	function validateForm(): boolean {
+		errors = {};
+		
+		if (!formData.title.trim()) {
+			errors.title = 'Title is required';
+		}
+		
+		if (!formData.description.trim()) {
+			errors.description = 'Description is required';
+		}
+		
+		if (!formData.author.trim()) {
+			errors.author = 'Author name is required';
+		}
+
+		return Object.keys(errors).length === 0;
+	}
+
+	function handleSubmit() {
+		if (validateForm()) {
+			dispatch('submit', formData);
+			// Reset form
+			formData = {
+				title: '',
+				description: '',
+				category: 'feature',
+				priority: 'medium',
+				author: '',
+				tags: []
+			};
+		}
+	}
+
+	function handleCancel() {
+		dispatch('cancel');
+	}
+</script>
+
+<form onsubmit|preventDefault={handleSubmit} class="space-y-4">
+	<!-- Title -->
+	<div class="form-control">
+		<label class="label" for="title">
+			<span class="label-text font-semibold">Title *</span>
+		</label>
+		<input 
+			id="title"
+			type="text" 
+			placeholder="Brief, descriptive title for your feature request"
+			class="input input-bordered w-full {errors.title ? 'input-error' : ''}"
+			bind:value={formData.title}
+			maxlength="100"
+		/>
+		{#if errors.title}
+			<label class="label">
+				<span class="label-text-alt text-error">{errors.title}</span>
+			</label>
+		{/if}
+	</div>
+
+	<!-- Description -->
+	<div class="form-control">
+		<label class="label" for="description">
+			<span class="label-text font-semibold">Description *</span>
+		</label>
+		<textarea 
+			id="description"
+			class="textarea textarea-bordered h-24 {errors.description ? 'textarea-error' : ''}"
+			placeholder="Provide detailed information about your feature request..."
+			bind:value={formData.description}
+			maxlength="1000"
+		></textarea>
+		{#if errors.description}
+			<label class="label">
+				<span class="label-text-alt text-error">{errors.description}</span>
+			</label>
+		{/if}
+		<label class="label">
+			<span class="label-text-alt">{formData.description.length}/1000 characters</span>
+		</label>
+	</div>
+
+	<!-- Category and Priority Row -->
+	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+		<!-- Category -->
+		<div class="form-control">
+			<label class="label" for="category">
+				<span class="label-text font-semibold">Category</span>
+			</label>
+			<select 
+				id="category"
+				class="select select-bordered w-full"
+				bind:value={formData.category}
+			>
+				<option value="ui">🎨 UI/Design</option>
+				<option value="feature">✨ New Feature</option>
+				<option value="improvement">📈 Improvement</option>
+				<option value="bug">🐛 Bug Fix</option>
+				<option value="other">💡 Other</option>
+			</select>
+		</div>
+
+		<!-- Priority -->
+		<div class="form-control">
+			<label class="label" for="priority">
+				<span class="label-text font-semibold">Priority</span>
+			</label>
+			<select 
+				id="priority"
+				class="select select-bordered w-full"
+				bind:value={formData.priority}
+			>
+				<option value="low">🟢 Low</option>
+				<option value="medium">🟡 Medium</option>
+				<option value="high">🟠 High</option>
+				<option value="critical">🔴 Critical</option>
+			</select>
+		</div>
+	</div>
+
+	<!-- Author -->
+	<div class="form-control">
+		<label class="label" for="author">
+			<span class="label-text font-semibold">Your Name *</span>
+		</label>
+		<input 
+			id="author"
+			type="text" 
+			placeholder="Enter your name or username"
+			class="input input-bordered w-full {errors.author ? 'input-error' : ''}"
+			bind:value={formData.author}
+			maxlength="50"
+		/>
+		{#if errors.author}
+			<label class="label">
+				<span class="label-text-alt text-error">{errors.author}</span>
+			</label>
+		{/if}
+	</div>
+
+	<!-- Tags -->
+	<div class="form-control">
+		<label class="label" for="tag-input">
+			<span class="label-text font-semibold">Tags</span>
+		</label>
+		<div class="flex gap-2">
+			<input 
+				id="tag-input"
+				type="text" 
+				placeholder="Add tags (press Enter)"
+				class="input input-bordered flex-1"
+				bind:value={tagInput}
+				onkeydown={handleTagKeydown}
+				maxlength="20"
+			/>
+			<button 
+				type="button" 
+				class="btn btn-outline"
+				onclick={addTag}
+				disabled={!tagInput.trim()}
+			>
+				Add
+			</button>
+		</div>
+		{#if formData.tags.length > 0}
+			<div class="flex flex-wrap gap-2 mt-2">
+				{#each formData.tags as tag}
+					<div class="badge badge-outline gap-2">
+						{tag}
+						<button 
+							type="button" 
+							class="btn btn-ghost btn-xs p-0 h-auto min-h-0"
+							onclick={() => removeTag(tag)}
+						>
+							✕
+						</button>
+					</div>
+				{/each}
+			</div>
+		{/if}
+		<label class="label">
+			<span class="label-text-alt">Tags help categorize and filter feature requests</span>
+		</label>
+	</div>
+
+	<!-- Action Buttons -->
+	<div class="modal-action">
+		<button type="button" class="btn btn-ghost" onclick={handleCancel}>
+			Cancel
+		</button>
+		<button type="submit" class="btn btn-primary">
+			Submit Feature Request
+		</button>
+	</div>
+</form>

--- a/src/routes/data/sidebar.ts
+++ b/src/routes/data/sidebar.ts
@@ -47,5 +47,9 @@ export const SIDEBAR = [
       title: "Customer Support",
       href: "/contact",
     },
+    {
+      title: "Brainstorm Board",
+      href: "/brainstorm",
+    },
   ];
   

--- a/src/types/brainstorm.ts
+++ b/src/types/brainstorm.ts
@@ -1,0 +1,48 @@
+export interface FeatureRequest {
+	id: string;
+	title: string;
+	description: string;
+	category: 'ui' | 'feature' | 'improvement' | 'bug' | 'other';
+	priority: 'low' | 'medium' | 'high' | 'critical';
+	status: 'requested' | 'in-review' | 'approved' | 'in-progress' | 'completed' | 'rejected';
+	author: string;
+	votes: number;
+	createdAt: string;
+	updatedAt: string;
+	tags: string[];
+	position?: {
+		x: number;
+		y: number;
+	};
+}
+
+export interface BrainstormBoard {
+	id: string;
+	title: string;
+	description: string;
+	features: FeatureRequest[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface CreateFeatureRequestData {
+	title: string;
+	description: string;
+	category: FeatureRequest['category'];
+	priority: FeatureRequest['priority'];
+	author: string;
+	tags: string[];
+}
+
+export interface UpdateFeatureRequestData {
+	title?: string;
+	description?: string;
+	category?: FeatureRequest['category'];
+	priority?: FeatureRequest['priority'];
+	status?: FeatureRequest['status'];
+	tags?: string[];
+	position?: {
+		x: number;
+		y: number;
+	};
+}


### PR DESCRIPTION
Add a comprehensive brainstorm board feature to allow users to submit, track, and vote on new feature requests for macosplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-9200a7ec-4984-4639-9580-8ee6366e310c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9200a7ec-4984-4639-9580-8ee6366e310c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

