### PR TITLE
Update outfit image display by shop and outfit ID

### DIFF
--- a/src/routes/store/[shopID]/[outfitID]/+page.svelte
+++ b/src/routes/store/[shopID]/[outfitID]/+page.svelte
@@ -70,8 +70,8 @@
 			return image;
 		}
 		
-		// If it's a relative path from PocketBase, construct the full URL
-		return `https://file.macosplay.com/mxj3660ce5olheb/${$page.params.shopID}/${image}`;
+		// If it's a relative path from PocketBase, construct the full URL using the outfit record id
+		return `https://file.macosplay.com/mxj3660ce5olheb/${outfit?.id || $page.params.outfitID}/${image}`;
 	}
 </script>
 


### PR DESCRIPTION
Use `outfitID` instead of `shopID` in image URLs on outfit pages to display the correct image.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0fa46cf-1036-4218-9949-f13bc820a794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0fa46cf-1036-4218-9949-f13bc820a794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

