### PR TITLE
Fix svelte build assignment error

### DIFF
--- a/src/routes/store/[shopID]/[outfitID]/+page.svelte
+++ b/src/routes/store/[shopID]/[outfitID]/+page.svelte
@@ -15,8 +15,8 @@
 	let showImageManager = false;
 
 	// Extract outfit and shop data
-	$: outfit: ItemData | null = data?.itemList?.[0] || null;
-	$: shop: ShopData | null = data?.userStore || null;
+	$: outfit = data?.itemList?.[0] || null;
+	$: shop = data?.userStore || null;
 	$: productImages = outfit?.Images ? 
 		(outfit.Images.filter((img: string) => img && img.trim() !== '')) : 
 		(outfit?.Image ? [outfit.Image] : []);


### PR DESCRIPTION
Remove type annotations from Svelte reactive statements to fix a build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cd7ea0a-31de-4cc8-999d-717dda8f208e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cd7ea0a-31de-4cc8-999d-717dda8f208e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

