### PR TITLE
Fix invalid shop ID length for store endpoint

### DIFF
--- a/src/routes/store/[shopID]/[outfitID]/+page.server.ts
+++ b/src/routes/store/[shopID]/[outfitID]/+page.server.ts
@@ -12,21 +12,25 @@ export const load = async ({ params }) => {
 	// Validate shopID format (should be alphanumeric, no special characters)
 	const shopIDRegex = /^[a-zA-Z0-9_-]+$/;
 	if (!shopIDRegex.test(shopID)) {
+		console.log(`Invalid shop ID format: ${shopID}`);
 		throw error(400, 'Invalid shop ID format');
 	}
 
 	// Validate outfitID format (should be alphanumeric, no special characters)
 	const outfitIDRegex = /^[a-zA-Z0-9_-]+$/;
 	if (!outfitIDRegex.test(outfitID)) {
+		console.log(`Invalid outfit ID format: ${outfitID}`);
 		throw error(400, 'Invalid outfit ID format');
 	}
 
-	// Length validation
-	if (shopID.length < 3 || shopID.length > 50) {
+	// Length validation - allow shorter IDs for flexibility
+	if (shopID.length < 1 || shopID.length > 100) {
+		console.log(`Shop ID length invalid: ${shopID} (length: ${shopID.length})`);
 		throw error(400, 'Shop ID length invalid');
 	}
 
-	if (outfitID.length < 3 || outfitID.length > 50) {
+	if (outfitID.length < 1 || outfitID.length > 100) {
+		console.log(`Outfit ID length invalid: ${outfitID} (length: ${outfitID.length})`);
 		throw error(400, 'Outfit ID length invalid');
 	}
 


### PR DESCRIPTION
Adjust shop ID length validation and enhance error handling to resolve 'Shop ID length invalid' errors.

The previous validation for `shopID` and `outfitID` required a minimum length of 3 characters, which was too restrictive and caused 400 errors for valid, shorter IDs. This PR relaxes the minimum length to 1 character and increases the maximum to 100 for flexibility, while also improving error logging and handling across related store endpoints.

---
<a href="https://cursor.com/background-agent?bcId=bc-f04d6279-791b-4452-b4a6-657a3baf10f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f04d6279-791b-4452-b4a6-657a3baf10f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

