### PR TITLE
Remove AI upscale section from landing page

### DIFF
--- a/src/routes/components/Hero.svelte
+++ b/src/routes/components/Hero.svelte
@@ -64,22 +64,6 @@
 					<div class="flex flex-col sm:flex-row md:flex-row mt-4 sm:mt-6 md:mt-8 lg:mt-10 gap-3 sm:gap-4">
 						<a
 							class="w-auto sm:w-32 md:w-40 lg:w-52 btn btn-sm sm:btn-md rounded-full flex items-center justify-center gap-2 text-xs sm:text-sm md:text-base px-4 sm:px-5 md:px-6"
-							href="/upscaler"
-						>
-							AI Upscale
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								width="16"
-								height="16"
-								fill="currentColor"
-								viewBox="0 0 24 24"
-								class="sm:w-4 sm:h-4 md:w-5 md:h-5"
-							>
-								<path d="M7 7h8.586L5.293 17.293l1.414 1.414L17 8.414V17h2V5H7v2z" />
-							</svg>
-						</a>
-						<a
-							class="w-auto sm:w-32 md:w-40 lg:w-52 btn btn-sm sm:btn-md rounded-full flex items-center justify-center gap-2 text-xs sm:text-sm md:text-base px-4 sm:px-5 md:px-6"
 							href="/manage-store"
 						>
 							เปิดร้านค้า


### PR DESCRIPTION
Remove the AI Upscale button from the main landing page's Hero component as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad8bdfb0-ad77-45b0-8ab3-992175df5d3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad8bdfb0-ad77-45b0-8ab3-992175df5d3d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

