### PR TITLE
Fix invalid svelte bind expression

### DIFF
--- a/src/routes/manage-store/[shopID]/+page.svelte
+++ b/src/routes/manage-store/[shopID]/+page.svelte
@@ -17,6 +17,19 @@
     let editImageFile = null;
     let itemToDelete = null; // Track the item to be deleted
     let showDeleteConfirm = false; // Control the visibility of the delete confirmation modal
+    let tagsString = ''; // String representation of tags for input binding
+
+    // Reactive statement to sync tagsString with editingItem.tags
+    $: if (editingItem && editingItem.tags) {
+        tagsString = editingItem.tags.join(', ');
+    } else if (editingItem) {
+        tagsString = '';
+    }
+
+    // Reactive statement to sync editingItem.tags with tagsString
+    $: if (editingItem && tagsString !== undefined) {
+        editingItem.tags = tagsString ? tagsString.split(',').map(tag => tag.trim()).filter(tag => tag) : [];
+    }
 
     function openEditModal(item) {
         editingItem = { ...item }; // Create a copy of the item
@@ -1122,7 +1135,7 @@
                     <input
                         type="text"
                         name="tags"
-                        bind:value={editingItem.tags ? editingItem.tags.join(', ') : ''}
+                        bind:value={tagsString}
                         class="input input-bordered w-full"
                         placeholder="เช่น: cosplay, genshin, anime"
                     />


### PR DESCRIPTION
Fix Svelte build error by refactoring tag input binding to use a reactive `tagsString` variable.

The previous `bind:value` expression was attempting to bind directly to a computed value (`editingItem.tags.join(', ')`), which is not allowed in Svelte. This change introduces a `tagsString` variable for the input field and uses reactive statements to maintain two-way synchronization between `tagsString` and the `editingItem.tags` array.

---
<a href="https://cursor.com/background-agent?bcId=bc-1155924c-a75d-4496-b956-220b5ae3b2b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1155924c-a75d-4496-b956-220b5ae3b2b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

